### PR TITLE
feat: pregenerate.sh 実行時に初回警告音声を再生

### DIFF
--- a/scripts/pregenerate.sh
+++ b/scripts/pregenerate.sh
@@ -74,6 +74,20 @@ echo "=== ずんだもん音声キャッシュ生成 ==="
 echo "キャッシュ先: $CACHE_DIR"
 echo ""
 
+# キャッシュが 0 件なら初回警告音声を再生（同期）
+WAV_COUNT=$(find "$CACHE_DIR" -maxdepth 1 -type f -name "*.wav" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$WAV_COUNT" -eq 0 ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+  INITIAL_WAV="${SCRIPT_DIR}/assets/initial_warning.wav"
+  if [ -f "$INITIAL_WAV" ]; then
+    if command -v aplay >/dev/null 2>&1; then
+      aplay -q "$INITIAL_WAV"
+    elif command -v paplay >/dev/null 2>&1; then
+      paplay "$INITIAL_WAV"
+    fi
+  fi
+fi
+
 # ツール音声の生成
 generate "PreToolUse_Bash"    "コマンドを実行するのだ"
 generate "PreToolUse_Write"   "ファイルを書き込むのだ"

--- a/scripts/pregenerate.sh
+++ b/scripts/pregenerate.sh
@@ -46,7 +46,7 @@ generate() {
 generate_to_assets() {
   local text="見知らぬ人のつくったhooksをよく見ないままインストールして使うことは、とても危険なのだ"
   local script_dir
-  script_dir="$(cd "$(dirname "$0")/.." && pwd)"
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
   local outfile="${script_dir}/assets/initial_warning.wav"
   mkdir -p "$(dirname "$outfile")"
   if [ -f "$outfile" ]; then
@@ -75,10 +75,10 @@ echo "キャッシュ先: $CACHE_DIR"
 echo ""
 
 # キャッシュが 0 件なら初回警告音声を再生（同期）
-WAV_COUNT=$(find "$CACHE_DIR" -maxdepth 1 -type f -name "*.wav" 2>/dev/null | wc -l | tr -d ' ')
-if [ "$WAV_COUNT" -eq 0 ]; then
-  SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-  INITIAL_WAV="${SCRIPT_DIR}/assets/initial_warning.wav"
+# BASH_SOURCE[0] でスクリプト自身のパスを確実に解決（PATH 経由の起動でも正しく動作する）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INITIAL_WAV="${SCRIPT_DIR}/assets/initial_warning.wav"
+if ! find "$CACHE_DIR" -maxdepth 1 -type f -name "*.wav" -print -quit 2>/dev/null | grep -q .; then
   if [ -f "$INITIAL_WAV" ]; then
     if command -v aplay >/dev/null 2>&1; then
       aplay -q "$INITIAL_WAV"


### PR DESCRIPTION
## Summary

- `~/.claude/hooks/zaudio/` に WAV が 0 件の状態で `pregenerate.sh` を実行すると、生成前に `assets/initial_warning.wav` を同期再生する
- README を読んで pregenerate.sh を実行するユーザーにも警告が届くようになる
- セッション開始（zunda-session-start.sh）と同じ条件で再生するため、どちらの経路でも警告が確実に届く

🤖 Generated with [Claude Code](https://claude.com/claude-code)