### PR TITLE
feat: Windows / macOS 対応（クロスプラットフォーム化）

### DIFF
--- a/.claude/hooks/zunda-session-start.sh
+++ b/.claude/hooks/zunda-session-start.sh
@@ -35,7 +35,12 @@ case "$OS" in
     ;;
   MINGW*|MSYS*|CYGWIN*)
     # Git Bash / MSYS2 / Cygwin on Windows
-    VOICEVOX_BIN="${LOCALAPPDATA}/Programs/VOICEVOX/VOICEVOX.exe"
+    if [ -z "${LOCALAPPDATA:-}" ]; then
+      echo "zunda-session-start: LOCALAPPDATA is not set; cannot locate VOICEVOX on Windows" >&2
+      VOICEVOX_BIN=""
+    else
+      VOICEVOX_BIN="${LOCALAPPDATA}/Programs/VOICEVOX/VOICEVOX.exe"
+    fi
     VOICEVOX_LAUNCH_OPTS=""
     ;;
   *)
@@ -52,11 +57,17 @@ play_wav() {
     Darwin*)
       afplay "$file" ;;
     MINGW*|MSYS*|CYGWIN*)
-      # cygpath が使える場合は Windows パスに変換してから PowerShell で再生
       local winpath
-      winpath=$(cygpath -w "$file" 2>/dev/null || echo "$file")
+      if command -v cygpath >/dev/null 2>&1; then
+        winpath=$(cygpath -w "$file")
+      else
+        # cygpath 不在時: /c/Users/... 形式を c:\Users\... 形式に手動変換
+        winpath=$(printf '%s' "$file" | sed 's|^/\([a-zA-Z]\)/|\1:/|;s|/|\\|g')
+      fi
+      # シングルクォートをエスケープ（PowerShell インジェクション防止）
+      local escaped="${winpath//\'/\'\'}"
       powershell.exe -NoProfile -Command \
-        "(New-Object Media.SoundPlayer '$winpath').PlaySync()" 2>/dev/null ;;
+        "(New-Object Media.SoundPlayer '$escaped').PlaySync()" 2>/dev/null ;;
     *)
       if command -v aplay >/dev/null 2>&1; then
         aplay -q "$file"

--- a/.claude/hooks/zunda-session-start.sh
+++ b/.claude/hooks/zunda-session-start.sh
@@ -4,7 +4,6 @@
 CACHE_DIR="$HOME/.claude/hooks/zaudio"
 SESSION_DIR="$CACHE_DIR/.sessions"
 VOICEVOX_URL="http://localhost:50021"
-VOICEVOX_BIN="$HOME/.voicevox/VOICEVOX.AppImage"
 PID_FILE="$CACHE_DIR/.voicevox.pid"
 
 # CLAUDE_PROJECT_DIR 未定義ガード
@@ -21,19 +20,57 @@ mkdir -p "$CACHE_DIR" "$SESSION_DIR"
 SESSION_ID=$(echo "${CLAUDE_SESSION_ID:-$$}" | tr -cd '[:alnum:]_-')
 [ -n "$SESSION_ID" ] && touch "$SESSION_DIR/$SESSION_ID"
 
-# 音声再生コマンドを選択
-if command -v aplay >/dev/null 2>&1; then
-  PLAYER="aplay -q"
-elif command -v paplay >/dev/null 2>&1; then
-  PLAYER="paplay"
-else
-  PLAYER=""
-fi
+# OS 判定
+OS=$(uname -s)
+
+# OS 別: VOICEVOX バイナリパス
+case "$OS" in
+  Linux*)
+    VOICEVOX_BIN="$HOME/.voicevox/VOICEVOX.AppImage"
+    VOICEVOX_LAUNCH_OPTS="--no-sandbox"
+    ;;
+  Darwin*)
+    VOICEVOX_BIN="/Applications/VOICEVOX.app/Contents/MacOS/VOICEVOX"
+    VOICEVOX_LAUNCH_OPTS=""
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    # Git Bash / MSYS2 / Cygwin on Windows
+    VOICEVOX_BIN="${LOCALAPPDATA}/Programs/VOICEVOX/VOICEVOX.exe"
+    VOICEVOX_LAUNCH_OPTS=""
+    ;;
+  *)
+    VOICEVOX_BIN=""
+    VOICEVOX_LAUNCH_OPTS=""
+    ;;
+esac
+
+# OS 別: WAV 再生関数
+play_wav() {
+  local file="$1"
+  [ -f "$file" ] || return
+  case "$OS" in
+    Darwin*)
+      afplay "$file" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      # cygpath が使える場合は Windows パスに変換してから PowerShell で再生
+      local winpath
+      winpath=$(cygpath -w "$file" 2>/dev/null || echo "$file")
+      powershell.exe -NoProfile -Command \
+        "(New-Object Media.SoundPlayer '$winpath').PlaySync()" 2>/dev/null ;;
+    *)
+      if command -v aplay >/dev/null 2>&1; then
+        aplay -q "$file"
+      elif command -v paplay >/dev/null 2>&1; then
+        paplay "$file"
+      fi ;;
+  esac
+}
 
 # VOICEVOX が未起動なら起動
 if ! curl -sf --connect-timeout 2 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
-  if [ -f "$VOICEVOX_BIN" ]; then
-    nohup "$VOICEVOX_BIN" --no-sandbox >/dev/null 2>&1 &
+  if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
+    # shellcheck disable=SC2086
+    nohup "$VOICEVOX_BIN" $VOICEVOX_LAUNCH_OPTS >/dev/null 2>&1 &
     echo $! > "$PID_FILE"
     echo "zunda-session-start: VOICEVOX starting (PID $(cat "$PID_FILE"))" >&2
     # エンジンが応答するまで待機（最大30秒）
@@ -42,19 +79,13 @@ if ! curl -sf --connect-timeout 2 "${VOICEVOX_URL}/version" >/dev/null 2>&1; the
       sleep 1
     done
   else
-    echo "zunda-session-start: VOICEVOX AppImage not found at $VOICEVOX_BIN" >&2
+    echo "zunda-session-start: VOICEVOX not found at $VOICEVOX_BIN" >&2
   fi
 fi
 
-# プレーヤーがなければ終了
-[ -z "$PLAYER" ] && exit 0
-
-# ツール音声 WAV の数を確認（initial_warning.wav は除く）
-WAV_COUNT=$(find "$CACHE_DIR" -maxdepth 1 -type f -name "*.wav" 2>/dev/null | wc -l | tr -d ' ')
-
-# キャッシュ未生成（初回）なら警告を再生
-if [ "$WAV_COUNT" -eq 0 ] && [ -f "$INITIAL_WAV" ]; then
-  $PLAYER "$INITIAL_WAV"  # 警告は同期再生（確実に聞かせる）
+# ツール音声 WAV の存在確認（キャッシュ未生成なら警告再生）
+if ! find "$CACHE_DIR" -maxdepth 1 -type f -name "*.wav" -print -quit 2>/dev/null | grep -q .; then
+  play_wav "$INITIAL_WAV"  # 警告は同期再生（確実に聞かせる）
 fi
 
 exit 0

--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -87,9 +87,16 @@ play_wav_bg() {
       afplay "$file" & ;;
     MINGW*|MSYS*|CYGWIN*)
       local winpath
-      winpath=$(cygpath -w "$file" 2>/dev/null || echo "$file")
+      if command -v cygpath >/dev/null 2>&1; then
+        winpath=$(cygpath -w "$file")
+      else
+        # cygpath 不在時: /c/Users/... 形式を c:\Users\... 形式に手動変換
+        winpath=$(printf '%s' "$file" | sed 's|^/\([a-zA-Z]\)/|\1:/|;s|/|\\|g')
+      fi
+      # シングルクォートをエスケープ（PowerShell インジェクション防止）
+      local escaped="${winpath//\'/\'\'}"
       powershell.exe -NoProfile -Command \
-        "(New-Object Media.SoundPlayer '$winpath').PlaySync()" 2>/dev/null & ;;
+        "(New-Object Media.SoundPlayer '$escaped').PlaySync()" 2>/dev/null & ;;
     *)
       if command -v aplay >/dev/null 2>&1; then
         aplay -q "$file" &

--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -77,22 +77,36 @@ mkdir -p "$CACHE_DIR"
 SAFE_KEY=$(echo "$CACHE_KEY" | tr -cd '[:alnum:]_')
 CACHE_FILE="$CACHE_DIR/${SAFE_KEY}.wav"
 
-# 音声再生コマンドを選択
-if command -v aplay >/dev/null 2>&1; then
-  PLAYER="aplay -q"
-elif command -v paplay >/dev/null 2>&1; then
-  PLAYER="paplay"
-else
-  echo "zunda-speak: no audio player found (aplay/paplay)" >&2
-  exit 0
-fi
+# OS 別: WAV 再生関数（バックグラウンド再生）
+OS=$(uname -s)
+play_wav_bg() {
+  local file="$1"
+  [ -f "$file" ] || return
+  case "$OS" in
+    Darwin*)
+      afplay "$file" & ;;
+    MINGW*|MSYS*|CYGWIN*)
+      local winpath
+      winpath=$(cygpath -w "$file" 2>/dev/null || echo "$file")
+      powershell.exe -NoProfile -Command \
+        "(New-Object Media.SoundPlayer '$winpath').PlaySync()" 2>/dev/null & ;;
+    *)
+      if command -v aplay >/dev/null 2>&1; then
+        aplay -q "$file" &
+      elif command -v paplay >/dev/null 2>&1; then
+        paplay "$file" &
+      else
+        echo "zunda-speak: no audio player found (aplay/paplay/afplay)" >&2
+      fi ;;
+  esac
+}
 
 # キャッシュヒット → 即再生（0バイトファイルは無効として削除）
 if [ -f "$CACHE_FILE" ]; then
   if [ ! -s "$CACHE_FILE" ]; then
     rm -f "$CACHE_FILE"
   else
-    $PLAYER "$CACHE_FILE" &
+    play_wav_bg "$CACHE_FILE"
     exit 0
   fi
 fi
@@ -116,7 +130,7 @@ curl -sf --connect-timeout 10 -X POST \
 # 正常なサイズか確認してからキャッシュに配置
 if [ -s "$TMP_FILE" ]; then
   mv "$TMP_FILE" "$CACHE_FILE"
-  $PLAYER "$CACHE_FILE" &
+  play_wav_bg "$CACHE_FILE"
 else
   rm -f "$TMP_FILE"
 fi

--- a/README.md
+++ b/README.md
@@ -7,28 +7,35 @@ Claude Code のツール実行時にずんだもん（VOICEVOX）が喋る Claud
 
 ## 要件
 
-| ツール | 確認コマンド |
-|---|---|
-| jq | `jq --version` |
-| aplay または paplay | `aplay --version` |
-| curl | `curl --version` |
-| python3 | `python3 --version` |
-| VOICEVOX (v0.25.1+) | `~/.voicevox/VOICEVOX.AppImage` |
-
-### jq のインストール（未インストールの場合）
-
-```bash
-sudo apt install jq   # Debian/Ubuntu
-```
+| ツール | Linux | macOS | Windows (Git Bash) |
+|---|---|---|---|
+| jq | `sudo apt install jq` | `brew install jq` | `winget install jqlang.jq` |
+| 音声再生 | `aplay` または `paplay` | `afplay`（標準搭載） | PowerShell（標準搭載） |
+| curl | 通常標準搭載 | 通常標準搭載 | Git Bash に同梱 |
+| python3 | 通常標準搭載 | 通常標準搭載 | `winget install Python.Python.3` |
+| VOICEVOX | `~/.voicevox/VOICEVOX.AppImage` | `/Applications/VOICEVOX.app` | `%LOCALAPPDATA%\Programs\VOICEVOX\VOICEVOX.exe` |
 
 ## セットアップ
 
 ### 1. VOICEVOX を起動
 
+**Linux**
 ```bash
 ~/.voicevox/VOICEVOX.AppImage --no-sandbox &
-# エンジンが起動するまで数秒待つ
-curl http://localhost:50021/version
+curl http://localhost:50021/version  # 起動確認
+```
+
+**macOS**
+```bash
+open -a VOICEVOX
+curl http://localhost:50021/version  # 起動確認
+```
+
+**Windows（Git Bash）**
+```bash
+# スタートメニューから VOICEVOX を起動するか:
+"$LOCALAPPDATA/Programs/VOICEVOX/VOICEVOX.exe" &
+curl http://localhost:50021/version  # 起動確認
 ```
 
 ### 2. 音声を事前生成


### PR DESCRIPTION
## Summary

- `uname -s` で OS を判定し、Linux / macOS / Windows (Git Bash) で動作するよう分岐
- VOICEVOX のバイナリパスと起動オプションを OS 別に設定
- 音声再生コマンドを `play_wav` / `play_wav_bg` 関数に統一

## OS 別の対応内容

| 項目 | Linux | macOS | Windows (Git Bash) |
|---|---|---|---|
| VOICEVOX パス | `~/.voicevox/VOICEVOX.AppImage` | `/Applications/VOICEVOX.app/Contents/MacOS/VOICEVOX` | `$LOCALAPPDATA/Programs/VOICEVOX/VOICEVOX.exe` |
| 起動オプション | `--no-sandbox` | なし | なし |
| 音声再生 | `aplay -q` / `paplay` | `afplay` | PowerShell + `Media.SoundPlayer` |

## 変更ファイル

- `.claude/hooks/zunda-session-start.sh`: OS 判定 + 分岐追加
- `.claude/hooks/zunda-speak.sh`: `play_wav_bg` 関数で OS 別再生
- `README.md`: 要件表とセットアップ手順を OS 別に整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)