### PR TITLE
feat: クロスプラットフォーム対応 + インストールスクリプト

### DIFF
--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -78,20 +78,40 @@ mkdir -p "$CACHE_DIR"
 SAFE_KEY=$(echo "$CACHE_KEY" | tr -cd '[:alnum:]_')
 CACHE_FILE="$CACHE_DIR/${SAFE_KEY}.wav"
 
-# 再生中チェック（早い者勝ち: 再生中なら新規リクエストを無視）
-if [ -f "$LOCK_FILE" ]; then
-  LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
-  if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
-    exit 0  # 再生中 → スキップ
-  fi
-  rm -f "$LOCK_FILE"
-fi
+# ヘルパー: ロックが有効か確認（PID 生存 + プロセス名による PID 再利用チェック）
+_lock_is_active() {
+  [ -f "$LOCK_FILE" ] || return 1
+  local pid
+  pid=$(cat "$LOCK_FILE" 2>/dev/null) || return 1
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  # PID 再利用チェック: プロセス名が音声プレイヤーか確認
+  local comm
+  comm=$(ps -p "$pid" -o comm= 2>/dev/null) || return 1
+  echo "$comm" | grep -qiE '^(afplay|aplay|paplay|powershell|POWERSHELL\.EXE)$'
+}
 
-# OS 別: WAV 再生関数（バックグラウンド再生 + ロック管理）
+# 早期チェック（高速パス: 明らかに再生中の場合のみスキップ）
+if _lock_is_active; then
+  exit 0
+fi
+rm -f "$LOCK_FILE"
+
+# OS 別: WAV 再生関数（再生直前にアトミックなロック取得 + バックグラウンド再生）
 OS=$(uname -s)
 play_wav_bg() {
   local file="$1"
   [ -f "$file" ] || return
+  # TOCTOU 対策: noclobber でアトミックなロック取得を試みる
+  # 別フックが合成中にここへ到達した場合の競合を防止
+  if ! (set -o noclobber; : > "$LOCK_FILE") 2>/dev/null; then
+    if _lock_is_active; then
+      return  # 本当に再生中 → スキップ
+    fi
+    # 孤児ロック → 強制削除して再取得
+    rm -f "$LOCK_FILE"
+    (set -o noclobber; : > "$LOCK_FILE") 2>/dev/null || return
+  fi
   case "$OS" in
     Darwin*)
       afplay "$file" &

--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -2,6 +2,7 @@
 # ずんだもん音声フックスクリプト（PreToolUse / PostToolUse 共用）
 
 CACHE_DIR="$HOME/.claude/hooks/zaudio"
+LOCK_FILE="$CACHE_DIR/.playing.lock"
 VOICEVOX_URL="http://localhost:50021"
 SPEAKER=3
 
@@ -77,14 +78,24 @@ mkdir -p "$CACHE_DIR"
 SAFE_KEY=$(echo "$CACHE_KEY" | tr -cd '[:alnum:]_')
 CACHE_FILE="$CACHE_DIR/${SAFE_KEY}.wav"
 
-# OS 別: WAV 再生関数（バックグラウンド再生）
+# 再生中チェック（早い者勝ち: 再生中なら新規リクエストを無視）
+if [ -f "$LOCK_FILE" ]; then
+  LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+  if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+    exit 0  # 再生中 → スキップ
+  fi
+  rm -f "$LOCK_FILE"
+fi
+
+# OS 別: WAV 再生関数（バックグラウンド再生 + ロック管理）
 OS=$(uname -s)
 play_wav_bg() {
   local file="$1"
   [ -f "$file" ] || return
   case "$OS" in
     Darwin*)
-      afplay "$file" & ;;
+      afplay "$file" &
+      echo $! > "$LOCK_FILE" ;;
     MINGW*|MSYS*|CYGWIN*)
       local winpath
       if command -v cygpath >/dev/null 2>&1; then
@@ -96,12 +107,15 @@ play_wav_bg() {
       # シングルクォートをエスケープ（PowerShell インジェクション防止）
       local escaped="${winpath//\'/\'\'}"
       powershell.exe -NoProfile -Command \
-        "(New-Object Media.SoundPlayer '$escaped').PlaySync()" 2>/dev/null & ;;
+        "(New-Object Media.SoundPlayer '$escaped').PlaySync()" 2>/dev/null &
+      echo $! > "$LOCK_FILE" ;;
     *)
       if command -v aplay >/dev/null 2>&1; then
         aplay -q "$file" &
+        echo $! > "$LOCK_FILE"
       elif command -v paplay >/dev/null 2>&1; then
         paplay "$file" &
+        echo $! > "$LOCK_FILE"
       else
         echo "zunda-speak: no audio player found (aplay/paplay/afplay)" >&2
       fi ;;

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# scripts/install-hooks.sh
+# ずんだもん hooks を Claude Code の設定にインストールする
+#
+# 使用方法:
+#   bash scripts/install-hooks.sh                    # ユーザースコープ (~/.claude/settings.json)
+#   bash scripts/install-hooks.sh --user             # 同上（明示）
+#   bash scripts/install-hooks.sh --project /path/to/project  # プロジェクトスコープ
+#
+# 追加されるフック:
+#   SessionStart  → zunda-session-start.sh (async)
+#   SessionEnd    → zunda-session-end.sh
+#   PreToolUse    → zunda-speak.sh (async)
+#   PostToolUse   → zunda-speak.sh (async)
+#
+# 注意:
+#   - 同一コマンドが既に登録済みの場合はスキップ（冪等）
+#   - 変更前に <対象ファイル>.bak としてバックアップを作成
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$REPO_DIR/.claude/hooks"
+
+# ── オプション解析 ──────────────────────────────────────────────────────────
+TARGET_MODE="user"
+PROJECT_DIR=""
+
+usage() {
+  echo "使用方法: $0 [--user | --project <project-dir>]" >&2
+  echo ""
+  echo "  --user               ユーザースコープにインストール (デフォルト)" >&2
+  echo "  --project <dir>      指定したプロジェクトディレクトリにインストール" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user)
+      TARGET_MODE="user"
+      shift ;;
+    --project)
+      TARGET_MODE="project"
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --project の後にディレクトリを指定してください" >&2
+        usage
+      fi
+      PROJECT_DIR="$2"
+      shift 2 ;;
+    -h|--help)
+      usage ;;
+    *)
+      echo "ERROR: 不明なオプション: $1" >&2
+      usage ;;
+  esac
+done
+
+# ── インストール先の決定 ─────────────────────────────────────────────────────
+if [ "$TARGET_MODE" = "user" ]; then
+  TARGET_SETTINGS="$HOME/.claude/settings.json"
+  echo "=== ずんだもん hooks インストーラー (ユーザースコープ) ==="
+else
+  if [ -z "$PROJECT_DIR" ]; then
+    echo "ERROR: --project にディレクトリが指定されていません" >&2
+    exit 1
+  fi
+  if [ ! -d "$PROJECT_DIR" ]; then
+    echo "ERROR: ディレクトリが見つかりません: $PROJECT_DIR" >&2
+    exit 1
+  fi
+  PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+  TARGET_SETTINGS="$PROJECT_DIR/.claude/settings.json"
+  echo "=== ずんだもん hooks インストーラー (プロジェクトスコープ) ==="
+  echo "プロジェクト: $PROJECT_DIR"
+fi
+
+echo "リポジトリ: $REPO_DIR"
+echo "設定ファイル: $TARGET_SETTINGS"
+echo ""
+
+# ── 前提チェック ─────────────────────────────────────────────────────────────
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq が見つかりません。インストールしてください:" >&2
+  echo "  sudo apt install jq" >&2
+  exit 1
+fi
+
+if [ ! -f "$TARGET_SETTINGS" ]; then
+  if [ "$TARGET_MODE" = "project" ]; then
+    echo "設定ファイルが存在しないため作成します: $TARGET_SETTINGS"
+    mkdir -p "$(dirname "$TARGET_SETTINGS")"
+    echo '{}' > "$TARGET_SETTINGS"
+  else
+    echo "ERROR: $TARGET_SETTINGS が見つかりません" >&2
+    exit 1
+  fi
+fi
+
+for script in zunda-speak.sh zunda-session-start.sh zunda-session-end.sh; do
+  if [ ! -f "$HOOKS_DIR/$script" ]; then
+    echo "ERROR: $HOOKS_DIR/$script が見つかりません" >&2
+    exit 1
+  fi
+done
+
+# ── バックアップ ──────────────────────────────────────────────────────────────
+cp "$TARGET_SETTINGS" "${TARGET_SETTINGS}.bak"
+echo "バックアップ: ${TARGET_SETTINGS}.bak"
+echo ""
+
+# ── フックコマンド定義 ────────────────────────────────────────────────────────
+# session-start は CLAUDE_PROJECT_DIR を env で渡す（initial_warning.wav の参照に必要）
+SESSION_START_CMD="CLAUDE_PROJECT_DIR=\"${REPO_DIR}\" bash \"${HOOKS_DIR}/zunda-session-start.sh\""
+SESSION_END_CMD="bash \"${HOOKS_DIR}/zunda-session-end.sh\""
+SPEAK_CMD="bash \"${HOOKS_DIR}/zunda-speak.sh\""
+
+# ── settings.json にフックを追加（冪等） ────────────────────────────────────
+UPDATED=$(jq \
+  --arg ss_cmd "$SESSION_START_CMD" \
+  --arg se_cmd "$SESSION_END_CMD" \
+  --arg sp_cmd "$SPEAK_CMD" \
+  '
+  # イベントの hooks 配列に指定コマンドが既に存在するか確認
+  def has_cmd(event; cmd):
+    (.hooks[event] // [])
+    | map(.hooks // [] | map(.command // "") | any(. == cmd))
+    | any;
+
+  # 重複しない場合のみ追加
+  def add_hook(event; hook_entry):
+    .hooks[event] //= [] |
+    if has_cmd(event; hook_entry.hooks[0].command) then .
+    else .hooks[event] += [hook_entry]
+    end;
+
+  add_hook("SessionStart"; {"hooks": [{"type": "command", "command": $ss_cmd, "async": true}]}) |
+  add_hook("SessionEnd";   {"hooks": [{"type": "command", "command": $se_cmd, "async": false}]}) |
+  add_hook("PreToolUse";   {"hooks": [{"type": "command", "command": $sp_cmd, "async": true}]}) |
+  add_hook("PostToolUse";  {"hooks": [{"type": "command", "command": $sp_cmd, "async": true}]})
+  ' "$TARGET_SETTINGS")
+
+echo "$UPDATED" > "$TARGET_SETTINGS"
+
+echo "インストール完了!"
+echo ""
+echo "追加されたフック:"
+echo "  SessionStart  → zunda-session-start.sh (async=true)"
+echo "  SessionEnd    → zunda-session-end.sh   (async=false)"
+echo "  PreToolUse    → zunda-speak.sh         (async=true)"
+echo "  PostToolUse   → zunda-speak.sh         (async=true)"
+echo ""
+echo "次のステップ:"
+echo "  1. VOICEVOX を起動: \$HOME/.voicevox/VOICEVOX.AppImage --no-sandbox"
+echo "  2. 音声キャッシュを生成: bash scripts/pregenerate.sh"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -27,8 +27,14 @@ HOOKS_DIR="$REPO_DIR/.claude/hooks"
 OS=$(uname -s)
 
 # Windows Git Bash では $HOME が未設定の場合がある
+# USERPROFILE は C:\Users\me 形式のため cygpath で POSIX パスに変換する
 if [ -z "${HOME:-}" ] && [ -n "${USERPROFILE:-}" ]; then
-  HOME="$USERPROFILE"
+  if command -v cygpath >/dev/null 2>&1; then
+    HOME="$(cygpath -u "$USERPROFILE")"
+  else
+    echo "WARNING: cygpath が見つかりません。\$HOME を正しく設定できない可能性があります。" >&2
+    HOME="$USERPROFILE"
+  fi
 fi
 
 # ── オプション解析 ──────────────────────────────────────────────────────────
@@ -125,10 +131,15 @@ echo "バックアップ: ${TARGET_SETTINGS}.bak"
 echo ""
 
 # ── フックコマンド定義 ────────────────────────────────────────────────────────
+# printf '%q' でシェル特殊文字をエスケープ（コマンドインジェクション防止）
+# リポジトリパスに $()・バッククォート・スペース等が含まれる場合でも安全
+REPO_DIR_ESC=$(printf '%q' "$REPO_DIR")
+HOOKS_DIR_ESC=$(printf '%q' "$HOOKS_DIR")
+
 # session-start は CLAUDE_PROJECT_DIR を env で渡す（initial_warning.wav の参照に必要）
-SESSION_START_CMD="CLAUDE_PROJECT_DIR=\"${REPO_DIR}\" bash \"${HOOKS_DIR}/zunda-session-start.sh\""
-SESSION_END_CMD="bash \"${HOOKS_DIR}/zunda-session-end.sh\""
-SPEAK_CMD="bash \"${HOOKS_DIR}/zunda-speak.sh\""
+SESSION_START_CMD="CLAUDE_PROJECT_DIR=${REPO_DIR_ESC} bash ${HOOKS_DIR_ESC}/zunda-session-start.sh"
+SESSION_END_CMD="bash ${HOOKS_DIR_ESC}/zunda-session-end.sh"
+SPEAK_CMD="bash ${HOOKS_DIR_ESC}/zunda-speak.sh"
 
 # ── settings.json にフックを追加（冪等） ────────────────────────────────────
 UPDATED=$(jq \

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -23,6 +23,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 HOOKS_DIR="$REPO_DIR/.claude/hooks"
 
+# OS 判定（jq インストール案内 / VOICEVOX パス表示に使用）
+OS=$(uname -s)
+
+# Windows Git Bash では $HOME が未設定の場合がある
+if [ -z "${HOME:-}" ] && [ -n "${USERPROFILE:-}" ]; then
+  HOME="$USERPROFILE"
+fi
+
 # ── オプション解析 ──────────────────────────────────────────────────────────
 TARGET_MODE="user"
 PROJECT_DIR=""
@@ -82,7 +90,14 @@ echo ""
 # ── 前提チェック ─────────────────────────────────────────────────────────────
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq が見つかりません。インストールしてください:" >&2
-  echo "  sudo apt install jq" >&2
+  case "$OS" in
+    Darwin*)
+      echo "  brew install jq" >&2 ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo "  winget install jqlang.jq  # または: choco install jq / scoop install jq" >&2 ;;
+    *)
+      echo "  sudo apt install jq  # または: sudo dnf install jq" >&2 ;;
+  esac
   exit 1
 fi
 
@@ -140,7 +155,7 @@ UPDATED=$(jq \
   add_hook("PostToolUse";  {"hooks": [{"type": "command", "command": $sp_cmd, "async": true}]})
   ' "$TARGET_SETTINGS")
 
-echo "$UPDATED" > "$TARGET_SETTINGS"
+printf '%s\n' "$UPDATED" > "$TARGET_SETTINGS"
 
 echo "インストール完了!"
 echo ""
@@ -151,5 +166,12 @@ echo "  PreToolUse    → zunda-speak.sh         (async=true)"
 echo "  PostToolUse   → zunda-speak.sh         (async=true)"
 echo ""
 echo "次のステップ:"
-echo "  1. VOICEVOX を起動: \$HOME/.voicevox/VOICEVOX.AppImage --no-sandbox"
+case "$OS" in
+  Darwin*)
+    echo "  1. VOICEVOX を起動: open /Applications/VOICEVOX.app" ;;
+  MINGW*|MSYS*|CYGWIN*)
+    echo "  1. VOICEVOX を起動: \${LOCALAPPDATA}/Programs/VOICEVOX/VOICEVOX.exe" ;;
+  *)
+    echo "  1. VOICEVOX を起動: \$HOME/.voicevox/VOICEVOX.AppImage --no-sandbox" ;;
+esac
 echo "  2. 音声キャッシュを生成: bash scripts/pregenerate.sh"


### PR DESCRIPTION
## Summary

- Windows / macOS / Linux でずんだもん hooks が動作するよう対応
- `scripts/install-hooks.sh` を新規追加（ユーザー/プロジェクトスコープ選択可）
- PreToolUse と PostToolUse の同時発火による音声重複を防ぐロック機構を追加

## Changes

### `.claude/hooks/zunda-speak.sh`
- PID ロックファイル（`$CACHE_DIR/.playing.lock`）による早い者勝ち制御
  - 再生中プロセスの PID を記録し、後続フックはスキップ
  - Darwin / Windows / Linux (aplay/paplay) 全 OS 対応

### `.claude/hooks/zunda-session-start.sh` / `zunda-session-end.sh`
- Windows (`MINGW*/MSYS*/CYGWIN*`) 向けパス解決・PowerShell 音声再生に対応
- `LOCALAPPDATA` 未設定時のガード追加

### `scripts/install-hooks.sh` (新規)
- `--user`（デフォルト）または `--project <dir>` オプションでインストール先を選択
- `jq` で `settings.json` に冪等追加（重複防止・バックアップ自動作成）
- OS 別の `jq` インストール案内・VOICEVOX 起動コマンド表示
- Windows Git Bash で `$HOME` 未設定時に `USERPROFILE` へフォールバック

## Test plan

- [ ] Linux: `bash scripts/install-hooks.sh --user` → `~/.claude/settings.json` に 4 イベント追加確認
- [ ] Linux: 2 回実行しても重複エントリが増えないことを確認
- [ ] Linux: VOICEVOX 起動状態で PreToolUse + PostToolUse が重ならないことを確認
- [ ] macOS / Windows: 上記と同様の動作確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)