### PR TITLE
fix: キャッシュが全て揃っている場合はVOICEVOX起動をスキップ

### DIFF
--- a/.claude/hooks/zunda-session-start.sh
+++ b/.claude/hooks/zunda-session-start.sh
@@ -77,23 +77,24 @@ play_wav() {
   esac
 }
 
-# 必須キャッシュファイルがすべて存在するか確認
-REQUIRED_CACHE_KEYS=(
-  "PreToolUse_Bash" "PreToolUse_Write" "PreToolUse_Edit"
-  "PreToolUse_Read" "PreToolUse_Glob" "PreToolUse_Grep"
-  "PostToolUse_Bash" "PostToolUse_Write" "PostToolUse_Edit"
-  "PreToolUse_Bash_GitPush" "PreToolUse_Bash_GhPrCreate"
-  "PostToolUse_Bash_GitPush" "PostToolUse_Bash_GhPrCreate"
-)
-ALL_CACHED=true
-for key in "${REQUIRED_CACHE_KEYS[@]}"; do
-  if [ ! -s "$CACHE_DIR/${key}.wav" ]; then
-    ALL_CACHED=false
-    break
-  fi
-done
+# キャッシュマニフェストに記載された全ファイルが存在するか確認
+# マニフェストは pregenerate.sh 実行時に生成される
+# 注意: キャッシュ完備でも未知のツール名はリアルタイム合成が必要なため、
+#       VOICEVOX を使いたい場合は手動で起動するか pregenerate.sh を再実行してください
+CACHE_MANIFEST="$CACHE_DIR/.cache-manifest"
+ALL_CACHED=false
+if [ -f "$CACHE_MANIFEST" ]; then
+  ALL_CACHED=true
+  while IFS= read -r key || [ -n "$key" ]; do
+    [ -n "$key" ] || continue
+    if [ ! -s "$CACHE_DIR/${key}.wav" ]; then
+      ALL_CACHED=false
+      break
+    fi
+  done < "$CACHE_MANIFEST"
+fi
 
-# VOICEVOX が未起動なら起動（キャッシュが全て揃っている場合はスキップ）
+# VOICEVOX が未起動なら起動（マニフェスト記載のキャッシュが全て揃っている場合はスキップ）
 if [ "$ALL_CACHED" = "false" ] && ! curl -sf --connect-timeout 2 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
   if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
     # shellcheck disable=SC2086

--- a/.claude/hooks/zunda-session-start.sh
+++ b/.claude/hooks/zunda-session-start.sh
@@ -77,8 +77,24 @@ play_wav() {
   esac
 }
 
-# VOICEVOX が未起動なら起動
-if ! curl -sf --connect-timeout 2 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
+# 必須キャッシュファイルがすべて存在するか確認
+REQUIRED_CACHE_KEYS=(
+  "PreToolUse_Bash" "PreToolUse_Write" "PreToolUse_Edit"
+  "PreToolUse_Read" "PreToolUse_Glob" "PreToolUse_Grep"
+  "PostToolUse_Bash" "PostToolUse_Write" "PostToolUse_Edit"
+  "PreToolUse_Bash_GitPush" "PreToolUse_Bash_GhPrCreate"
+  "PostToolUse_Bash_GitPush" "PostToolUse_Bash_GhPrCreate"
+)
+ALL_CACHED=true
+for key in "${REQUIRED_CACHE_KEYS[@]}"; do
+  if [ ! -s "$CACHE_DIR/${key}.wav" ]; then
+    ALL_CACHED=false
+    break
+  fi
+done
+
+# VOICEVOX が未起動なら起動（キャッシュが全て揃っている場合はスキップ）
+if [ "$ALL_CACHED" = "false" ] && ! curl -sf --connect-timeout 2 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
   if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
     # shellcheck disable=SC2086
     nohup "$VOICEVOX_BIN" $VOICEVOX_LAUNCH_OPTS >/dev/null 2>&1 &

--- a/.claude/hooks/zunda-session-start.sh
+++ b/.claude/hooks/zunda-session-start.sh
@@ -87,6 +87,8 @@ if [ -f "$CACHE_MANIFEST" ]; then
   ALL_CACHED=true
   while IFS= read -r key || [ -n "$key" ]; do
     [ -n "$key" ] || continue
+    # パストラバーサル防止: 英数字・アンダースコアのみ許可
+    [[ "$key" =~ ^[A-Za-z0-9_]+$ ]] || continue
     if [ ! -s "$CACHE_DIR/${key}.wav" ]; then
       ALL_CACHED=false
       break

--- a/scripts/pregenerate.sh
+++ b/scripts/pregenerate.sh
@@ -88,42 +88,43 @@ if ! find "$CACHE_DIR" -maxdepth 1 -type f -name "*.wav" -print -quit 2>/dev/nul
   fi
 fi
 
+# ツール音声マップ（キー:テキスト）— ここが唯一の正とする
+# generate() 呼び出しとキャッシュマニフェストの両方をこの配列から生成するため、
+# 新しいキーを追加する際はここだけ変更すればよい
+TOOL_AUDIO_MAP=(
+  "PreToolUse_Bash:コマンドを実行するのだ"
+  "PreToolUse_Write:ファイルを書き込むのだ"
+  "PreToolUse_Edit:ファイルを編集するのだ"
+  "PreToolUse_Read:ファイルを読むのだ"
+  "PreToolUse_Glob:ファイルを探すのだ"
+  "PreToolUse_Grep:ファイルを検索するのだ"
+  "PostToolUse_Bash:コマンドが完了したのだ"
+  "PostToolUse_Write:書き込みが完了したのだ"
+  "PostToolUse_Edit:編集が完了したのだ"
+  "PreToolUse_Bash_GitPush:プッシュするのだ"
+  "PreToolUse_Bash_GhPrCreate:プルリクエストを作るのだ"
+  "PostToolUse_Bash_GitPush:プッシュが完了したのだ"
+  "PostToolUse_Bash_GhPrCreate:プルリクエストを作ったのだ"
+)
+
 # ツール音声の生成
-generate "PreToolUse_Bash"    "コマンドを実行するのだ"
-generate "PreToolUse_Write"   "ファイルを書き込むのだ"
-generate "PreToolUse_Edit"    "ファイルを編集するのだ"
-generate "PreToolUse_Read"    "ファイルを読むのだ"
-generate "PreToolUse_Glob"    "ファイルを探すのだ"
-generate "PreToolUse_Grep"    "ファイルを検索するのだ"
-generate "PostToolUse_Bash"   "コマンドが完了したのだ"
-generate "PostToolUse_Write"  "書き込みが完了したのだ"
-generate "PostToolUse_Edit"   "編集が完了したのだ"
-generate "PreToolUse_Bash_GitPush"     "プッシュするのだ"
-generate "PreToolUse_Bash_GhPrCreate"  "プルリクエストを作るのだ"
-generate "PostToolUse_Bash_GitPush"    "プッシュが完了したのだ"
-generate "PostToolUse_Bash_GhPrCreate" "プルリクエストを作ったのだ"
+for entry in "${TOOL_AUDIO_MAP[@]}"; do
+  key="${entry%%:*}"
+  text="${entry#*:}"
+  generate "$key" "$text"
+done
 
 # 初回警告音声の生成（assets/ へ保存）
 echo ""
 generate_to_assets
 
 # キャッシュマニフェストを更新（zunda-session-start.sh がキャッシュ完備を判断するために使用）
-# 注意: generate() で生成したキーのみを記録すること（generate_to_assets は対象外）
-cat > "$CACHE_DIR/.cache-manifest" <<'MANIFEST'
-PreToolUse_Bash
-PreToolUse_Write
-PreToolUse_Edit
-PreToolUse_Read
-PreToolUse_Glob
-PreToolUse_Grep
-PostToolUse_Bash
-PostToolUse_Write
-PostToolUse_Edit
-PreToolUse_Bash_GitPush
-PreToolUse_Bash_GhPrCreate
-PostToolUse_Bash_GitPush
-PostToolUse_Bash_GhPrCreate
-MANIFEST
+# TOOL_AUDIO_MAP からキーのみを抽出して書き出す（generate_to_assets は対象外）
+{
+  for entry in "${TOOL_AUDIO_MAP[@]}"; do
+    printf '%s\n' "${entry%%:*}"
+  done
+} > "$CACHE_DIR/.cache-manifest"
 echo "updated: .cache-manifest"
 
 echo ""

--- a/scripts/pregenerate.sh
+++ b/scripts/pregenerate.sh
@@ -107,6 +107,25 @@ generate "PostToolUse_Bash_GhPrCreate" "プルリクエストを作ったのだ"
 echo ""
 generate_to_assets
 
+# キャッシュマニフェストを更新（zunda-session-start.sh がキャッシュ完備を判断するために使用）
+# 注意: generate() で生成したキーのみを記録すること（generate_to_assets は対象外）
+cat > "$CACHE_DIR/.cache-manifest" <<'MANIFEST'
+PreToolUse_Bash
+PreToolUse_Write
+PreToolUse_Edit
+PreToolUse_Read
+PreToolUse_Glob
+PreToolUse_Grep
+PostToolUse_Bash
+PostToolUse_Write
+PostToolUse_Edit
+PreToolUse_Bash_GitPush
+PreToolUse_Bash_GhPrCreate
+PostToolUse_Bash_GitPush
+PostToolUse_Bash_GhPrCreate
+MANIFEST
+echo "updated: .cache-manifest"
+
 echo ""
 echo "=== 完了 ==="
 ls -lh "$CACHE_DIR"/*.wav 2>/dev/null || echo "(WAVファイルなし)"


### PR DESCRIPTION
## Summary
- セッション開始時に必須キャッシュファイル（13ファイル）が全て存在する場合、VOICEVOX の起動処理をスキップするよう変更
- `pregenerate.sh` 実行済みの環境では起動待ち（最大30秒）が不要になる
- `! -s` チェックにより、0バイトの破損ファイルも「未キャッシュ」と判定される

## Test plan
- [ ] `pregenerate.sh` 実行後にセッションを再起動し、VOICEVOX が起動されないことを確認
- [ ] キャッシュファイルを1つ削除した状態でセッションを再起動し、VOICEVOX が起動されることを確認
- [ ] キャッシュなし（初回）の状態でセッションを再起動し、VOICEVOX が起動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)