### PR TITLE
feat: キャッシュミス時にVOICEVOXをオンデマンド起動

### DIFF
--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -155,6 +155,7 @@ fi
 
 # キャッシュミス → VOICEVOX が未起動ならオンデマンド起動
 if ! curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
+  # OS別バイナリパスを解決
   case "$OS" in
     Linux*)
       VOICEVOX_BIN="$HOME/.voicevox/VOICEVOX.AppImage"
@@ -173,11 +174,26 @@ if ! curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; the
       VOICEVOX_BIN=""
       VOICEVOX_LAUNCH_OPTS="" ;;
   esac
-  if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
-    # shellcheck disable=SC2086
-    nohup "$VOICEVOX_BIN" $VOICEVOX_LAUNCH_OPTS >/dev/null 2>&1 &
-    echo $! > "$PID_FILE"
-    # エンジンが応答するまで待機（最大30秒）
+
+  # 起動ロック（noclobber）で排他制御: 1プロセスだけが起動担当となり他は待機
+  START_LOCK="$CACHE_DIR/.voicevox.starting"
+  if (set -o noclobber; : > "$START_LOCK") 2>/dev/null; then
+    # 起動ロック取得成功 → 自分がVOICEVOX起動担当
+    if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
+      # shellcheck disable=SC2086
+      nohup "$VOICEVOX_BIN" $VOICEVOX_LAUNCH_OPTS >/dev/null 2>&1 &
+      echo $! > "$PID_FILE"
+      # エンジンが応答するまで待機（最大30秒）
+      for i in $(seq 1 30); do
+        curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1 && break
+        sleep 1
+      done
+    else
+      echo "zunda-speak: VOICEVOX not found at ${VOICEVOX_BIN:-(unknown)}" >&2
+    fi
+    rm -f "$START_LOCK"
+  else
+    # 他プロセスが起動中 → 応答が来るまで待機（最大30秒）
     for i in $(seq 1 30); do
       curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1 && break
       sleep 1

--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -178,26 +178,38 @@ if ! curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; the
   # 起動ロック（noclobber）で排他制御: 1プロセスだけが起動担当となり他は待機
   START_LOCK="$CACHE_DIR/.voicevox.starting"
   if (set -o noclobber; : > "$START_LOCK") 2>/dev/null; then
+    # クラッシュ時のロックリーク防止: EXIT で必ずロックを解放する
+    trap 'rm -f "$START_LOCK"' EXIT
     # 起動ロック取得成功 → 自分がVOICEVOX起動担当
     if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
       # shellcheck disable=SC2086
       nohup "$VOICEVOX_BIN" $VOICEVOX_LAUNCH_OPTS >/dev/null 2>&1 &
       echo $! > "$PID_FILE"
       # エンジンが応答するまで待機（最大30秒）
+      started=false
       for i in $(seq 1 30); do
-        curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1 && break
+        if curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
+          started=true
+          break
+        fi
         sleep 1
       done
+      [ "$started" = "false" ] && echo "zunda-speak: VOICEVOX did not respond within 30s" >&2
     else
       echo "zunda-speak: VOICEVOX not found at ${VOICEVOX_BIN:-(unknown)}" >&2
     fi
     rm -f "$START_LOCK"
   else
     # 他プロセスが起動中 → 応答が来るまで待機（最大30秒）
+    waited=false
     for i in $(seq 1 30); do
-      curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1 && break
+      if curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
+        waited=true
+        break
+      fi
       sleep 1
     done
+    [ "$waited" = "false" ] && echo "zunda-speak: timed out waiting for VOICEVOX" >&2
   fi
 fi
 

--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -3,6 +3,7 @@
 
 CACHE_DIR="$HOME/.claude/hooks/zaudio"
 LOCK_FILE="$CACHE_DIR/.playing.lock"
+PID_FILE="$CACHE_DIR/.voicevox.pid"
 VOICEVOX_URL="http://localhost:50021"
 SPEAKER=3
 
@@ -152,7 +153,39 @@ if [ -f "$CACHE_FILE" ]; then
   fi
 fi
 
-# キャッシュミス → VOICEVOX で合成してキャッシュ保存（atomic write）
+# キャッシュミス → VOICEVOX が未起動ならオンデマンド起動
+if ! curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; then
+  case "$OS" in
+    Linux*)
+      VOICEVOX_BIN="$HOME/.voicevox/VOICEVOX.AppImage"
+      VOICEVOX_LAUNCH_OPTS="--no-sandbox" ;;
+    Darwin*)
+      VOICEVOX_BIN="/Applications/VOICEVOX.app/Contents/MacOS/VOICEVOX"
+      VOICEVOX_LAUNCH_OPTS="" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      if [ -n "${LOCALAPPDATA:-}" ]; then
+        VOICEVOX_BIN="${LOCALAPPDATA}/Programs/VOICEVOX/VOICEVOX.exe"
+      else
+        VOICEVOX_BIN=""
+      fi
+      VOICEVOX_LAUNCH_OPTS="" ;;
+    *)
+      VOICEVOX_BIN=""
+      VOICEVOX_LAUNCH_OPTS="" ;;
+  esac
+  if [ -n "$VOICEVOX_BIN" ] && [ -f "$VOICEVOX_BIN" ]; then
+    # shellcheck disable=SC2086
+    nohup "$VOICEVOX_BIN" $VOICEVOX_LAUNCH_OPTS >/dev/null 2>&1 &
+    echo $! > "$PID_FILE"
+    # エンジンが応答するまで待機（最大30秒）
+    for i in $(seq 1 30); do
+      curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1 && break
+      sleep 1
+    done
+  fi
+fi
+
+# VOICEVOX で合成してキャッシュ保存（atomic write）
 ENCODED_TEXT=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$TEXT")
 QUERY=$(curl -sf --connect-timeout 3 -X POST \
   "${VOICEVOX_URL}/audio_query?text=${ENCODED_TEXT}&speaker=${SPEAKER}" \

--- a/.claude/hooks/zunda-speak.sh
+++ b/.claude/hooks/zunda-speak.sh
@@ -199,6 +199,7 @@ if ! curl -sf --connect-timeout 1 "${VOICEVOX_URL}/version" >/dev/null 2>&1; the
       echo "zunda-speak: VOICEVOX not found at ${VOICEVOX_BIN:-(unknown)}" >&2
     fi
     rm -f "$START_LOCK"
+    trap - EXIT  # ロック解放済みなので EXIT トラップをリセット（他プロセスのロックを消さないため）
   else
     # 他プロセスが起動中 → 応答が来るまで待機（最大30秒）
     waited=false


### PR DESCRIPTION
## Summary
- キャッシュ完備でVOICEVOXが起動されない状態で未知ツールが呼ばれた場合、音声が無音になる問題を修正
- `zunda-speak.sh` のキャッシュミスパスに VOICEVOX オンデマンド起動ロジックを追加
- OS別のバイナリパス検出（Linux/macOS/Windows）と最大30秒の起動待機を実装
- 一度起動されればその後のキャッシュミスは即座に合成される

## Motivation
PR #10 でセッション開始時のVOICEVOX起動をスキップするよう変更したことで、
`Agent`・`WebFetch` 等のマニフェスト外ツールのリアルタイム合成が機能しなくなっていた（Codex指摘2）。

## Test plan
- [ ] `pregenerate.sh` 実行後、マニフェスト外ツール（例: `WebFetch`）を使い音声が再生されることを確認
- [ ] VOICEVOX が起動していない状態でキャッシュミスが発生し、自動起動されることを確認
- [ ] マニフェスト内ツールはキャッシュから即再生されることを確認（VOICEVOX起動なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)